### PR TITLE
fix(security): block SQL denylist bypass via comments (CVE-2025-55674)

### DIFF
--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -24,10 +24,12 @@ import re
 from collections.abc import Iterator
 from typing import Any, cast, TYPE_CHECKING
 
+import sqlglot
 import sqlparse
 from flask_babel import gettext as __
 from jinja2 import nodes, Template
 from sqlalchemy import and_
+from sqlglot import expressions as exp
 from sqlparse import keywords
 from sqlparse.lexer import Lexer
 from sqlparse.sql import (
@@ -177,11 +179,39 @@ def check_sql_functions_exist(
     """
     Check if the SQL statement contains any of the specified functions.
 
+    Parsing is done with sqlglot rather than sqlparse. sqlparse only recognises a
+    function when its name is *immediately* followed by "(", so a comment or extra
+    quoting between the name and the parenthesis (e.g. ``query_to_xml/**/(...)`` or
+    ``"query_to_xml"(...)``) hides the function from the denylist. This was the
+    DISALLOWED_SQL_FUNCTIONS bypass reported as CVE-2025-55674. sqlglot builds a
+    real AST and normalises the name, so those tricks no longer evade the check.
+
     :param sql: The SQL statement
-    :param function_list: The list of functions to search for
+    :param function_list: The set of (lower-case) function names to search for
     :param engine: The engine to use for parsing the SQL statement
     """
-    return ParsedQuery(sql, engine=engine).check_functions_exist(function_list)
+    if not function_list:
+        return False
+
+    dialect = SQLGLOT_DIALECTS.get(engine)
+    try:
+        statements = sqlglot.parse(sql, dialect=dialect)
+    except Exception:  # pylint: disable=broad-except
+        # sqlglot could not parse the statement (ParseError, tokenizer error,
+        # recursion limit, ...). Fall back to a conservative sqlparse scan on a
+        # comment-stripped copy so we never fail open and don't reject exotic but
+        # legitimate SQL that sqlglot doesn't understand.
+        stripped = sqlparse.format(sql, strip_comments=True)
+        return ParsedQuery(stripped, engine=engine).check_functions_exist(function_list)
+
+    for statement in statements:
+        if statement is None:
+            continue
+        for node in statement.find_all(exp.Func):
+            name = node.name if isinstance(node, exp.Anonymous) else node.sql_name()
+            if name and name.lower() in function_list:
+                return True
+    return False
 
 
 def strip_comments_from_sql(statement: str, engine: str = "base") -> str:

--- a/tests/unit_tests/sql_parse_tests.py
+++ b/tests/unit_tests/sql_parse_tests.py
@@ -1237,6 +1237,43 @@ def test_check_sql_functions_exist() -> None:
     )
 
 
+def test_check_sql_functions_exist_denylist_bypass() -> None:
+    """
+    Regression test for CVE-2025-55674: the DISALLOWED_SQL_FUNCTIONS denylist
+    could be bypassed by inserting a comment (or extra quoting) between the
+    function name and its opening parenthesis, which hid the call from the
+    sqlparse-based check. The sqlglot-based check must catch all of these.
+    """
+    denylist = {"query_to_xml", "version"}
+
+    # the exact evasion from the pentest report: a block comment before "("
+    assert check_sql_functions_exist(
+        "query_to_xml/**/('select usename from pg_user', true, false, '')",
+        denylist,
+        "postgresql",
+    )
+
+    for evasion in (
+        "select version/**/()",
+        "select version--x\n()",
+        "select query_to_xml/**/(1)",
+        "select pg_catalog.query_to_xml/**/(1)",
+        'select "query_to_xml"(1)',
+    ):
+        assert check_sql_functions_exist(evasion, denylist, "postgresql"), evasion
+
+    # benign statements must not trip the check (no false positives)
+    for benign in (
+        "select count(*) from some_table",
+        "select versionx(1)",
+        "select a, b from version",
+    ):
+        assert not check_sql_functions_exist(benign, denylist, "postgresql"), benign
+
+    # empty denylist short-circuits to False
+    assert not check_sql_functions_exist("select version()", set(), "postgresql")
+
+
 def test_sanitize_clause_valid():
     # regular clauses
     assert sanitize_clause("col = 1") == "col = 1"


### PR DESCRIPTION
# use jira for discussion
https://jira.eurodata.de/browse/EDM-1265
# description
The DISALLOWED_SQL_FUNCTIONS denylist was enforced by walking the sqlparse token tree for Function nodes. sqlparse only forms a Function when the name is immediately followed by "(", so inserting a comment (or quoting the name) between the name and the parenthesis hid the call from the check, e.g.

    query_to_xml/**/('SELECT ... FROM pg_user LIMIT 1', true, false, '')

reached the database and exfiltrated data through /api/v1/chart/data.

Rewrite check_sql_functions_exist to parse with sqlglot and walk exp.Func nodes with normalised names, matching upstream fix ce6d0d5 (Superset 5.0.0). A conservative comment-stripped sqlparse fallback is kept for the rare case sqlglot cannot parse the statement, so the check never fails open and does not reject exotic but valid SQL.

Adds a regression test covering block/line-comment, schema-qualified and quoted-identifier evasions, plus benign-query and empty-denylist cases.
